### PR TITLE
Replace ADD instructions by COPY in all Dockerfiles

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -19,12 +19,12 @@ RUN apt-get update -qq && \
 
 # PHP Extensions
 RUN docker-php-ext-install -j$(nproc) opcache pdo_mysql
-ADD conf/php.ini /usr/local/etc/php/conf.d/app.ini
+COPY conf/php.ini /usr/local/etc/php/conf.d/app.ini
 
 # Apache
-ADD errors /errors
+COPY errors /errors
 RUN a2enmod rewrite remoteip
-ADD conf/vhost.conf /etc/apache2/sites-available/000-default.conf
-ADD conf/apache.conf /etc/apache2/conf-available/z-app.conf
+COPY conf/vhost.conf /etc/apache2/sites-available/000-default.conf
+COPY conf/apache.conf /etc/apache2/conf-available/z-app.conf
 RUN a2enconf z-app
-ADD index.php /app/index.php
+COPY index.php /app/index.php

--- a/7.2-symfony/Dockerfile
+++ b/7.2-symfony/Dockerfile
@@ -16,4 +16,4 @@ RUN docker-php-ext-configure zip --with-libzip && \
 	docker-php-ext-install -j$(nproc) intl zip
 
 # Apache
-ADD conf/vhost.conf /etc/apache2/sites-available/000-default.conf
+COPY conf/vhost.conf /etc/apache2/sites-available/000-default.conf

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -19,12 +19,12 @@ RUN apt-get update -qq && \
 
 # PHP Extensions
 RUN docker-php-ext-install -j$(nproc) opcache pdo_mysql
-ADD conf/php.ini /usr/local/etc/php/conf.d/app.ini
+COPY conf/php.ini /usr/local/etc/php/conf.d/app.ini
 
 # Apache
-ADD errors /errors
+COPY errors /errors
 RUN a2enmod rewrite remoteip
-ADD conf/vhost.conf /etc/apache2/sites-available/000-default.conf
-ADD conf/apache.conf /etc/apache2/conf-available/z-app.conf
+COPY conf/vhost.conf /etc/apache2/sites-available/000-default.conf
+COPY conf/apache.conf /etc/apache2/conf-available/z-app.conf
 RUN a2enconf z-app
-ADD index.php /app/index.php
+COPY index.php /app/index.php

--- a/7.3-symfony/Dockerfile
+++ b/7.3-symfony/Dockerfile
@@ -16,4 +16,4 @@ RUN docker-php-ext-configure zip --with-libzip && \
 	docker-php-ext-install -j$(nproc) intl zip
 
 # Apache
-ADD conf/vhost.conf /etc/apache2/sites-available/000-default.conf
+COPY conf/vhost.conf /etc/apache2/sites-available/000-default.conf

--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -19,12 +19,12 @@ RUN apt-get update -qq && \
 
 # PHP Extensions
 RUN docker-php-ext-install -j$(nproc) opcache pdo_mysql
-ADD conf/php.ini /usr/local/etc/php/conf.d/app.ini
+COPY conf/php.ini /usr/local/etc/php/conf.d/app.ini
 
 # Apache
-ADD errors /errors
+COPY errors /errors
 RUN a2enmod rewrite remoteip
-ADD conf/vhost.conf /etc/apache2/sites-available/000-default.conf
-ADD conf/apache.conf /etc/apache2/conf-available/z-app.conf
+COPY conf/vhost.conf /etc/apache2/sites-available/000-default.conf
+COPY conf/apache.conf /etc/apache2/conf-available/z-app.conf
 RUN a2enconf z-app
-ADD index.php /app/index.php
+COPY index.php /app/index.php

--- a/7.4-symfony/Dockerfile
+++ b/7.4-symfony/Dockerfile
@@ -20,12 +20,12 @@ RUN apt-get update -qq && \
 # PHP Extensions
 RUN docker-php-ext-configure zip && \
 	docker-php-ext-install -j$(nproc) opcache pdo_mysql intl zip
-ADD conf/php.ini /usr/local/etc/php/conf.d/app.ini
+COPY conf/php.ini /usr/local/etc/php/conf.d/app.ini
 
 # Apache
-ADD errors /errors
+COPY errors /errors
 RUN a2enmod rewrite remoteip
-ADD conf/vhost.conf /etc/apache2/sites-available/000-default.conf
-ADD conf/apache.conf /etc/apache2/conf-available/z-app.conf
+COPY conf/vhost.conf /etc/apache2/sites-available/000-default.conf
+COPY conf/apache.conf /etc/apache2/conf-available/z-app.conf
 RUN a2enconf z-app
-ADD index.php /app/index.php
+COPY index.php /app/index.php

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -17,12 +17,12 @@ RUN apt-get update -qq && \
 
 # PHP Extensions
 RUN docker-php-ext-install -j$(nproc) opcache pdo_mysql
-ADD conf/php.ini /usr/local/etc/php/conf.d/app.ini
+COPY conf/php.ini /usr/local/etc/php/conf.d/app.ini
 
 # Apache
-ADD errors /errors
+COPY errors /errors
 RUN a2enmod rewrite remoteip
-ADD conf/vhost.conf /etc/apache2/sites-available/000-default.conf
-ADD conf/apache.conf /etc/apache2/conf-available/z-app.conf
+COPY conf/vhost.conf /etc/apache2/sites-available/000-default.conf
+COPY conf/apache.conf /etc/apache2/conf-available/z-app.conf
 RUN a2enconf z-app
-ADD index.php /app/index.php
+COPY index.php /app/index.php


### PR DESCRIPTION
As recommended in Docker's [best practices for writing Dockerfiles](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy):

> Although ADD and COPY are functionally similar, generally speaking, COPY is preferred. That’s because it’s more transparent than ADD. COPY only supports the basic copying of local files into the container, while ADD has some features (like local-only tar extraction and remote URL support) that are not immediately obvious. Consequently, the best use for ADD is local tar file auto-extraction into the image, as in ADD rootfs.tar.xz /.