### PR TITLE
Improve CI readability and consolidate PHP versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,61 +13,87 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        path-and-tag:
-          - '8.5:latest'
-          - '8.5-ci:8.5-ci'
-          - '8.5:8.5'
-          - '8.5-frankenphp-alpine:8.5-frankenphp-alpine'
-          - '8.5-frankenphp-bookworm:8.5-frankenphp-bookworm'
-          - '8.5-symfony:8.5-symfony'
-          - '8.4-ci:8.4-ci'
-          - '8.4:8.4'
-          - '8.4-frankenphp-alpine:8.4-frankenphp-alpine'
-          - '8.4-frankenphp-bookworm:8.4-frankenphp-bookworm'
-          - '8.4-symfony:8.4-symfony'
-          - '8.3-ci:8.3-ci'
-          - '8.3:8.3'
-          - '8.3-frankenphp-alpine:8.3-frankenphp-alpine'
-          - '8.3-frankenphp-bookworm:8.3-frankenphp-bookworm'
-          - '8.3-symfony:8.3-symfony'
-          - '8.2-ci:8.2-ci'
-          - '8.2:8.2'
-          - '8.2-frankenphp-alpine:8.2-frankenphp-alpine'
-          - '8.2-frankenphp-bookworm:8.2-frankenphp-bookworm'
-          - '8.2-symfony:8.2-symfony'
-          - '8.1-ci:8.1-ci'
-          - '8.1:8.1'
-          - '8.1-symfony:8.1-symfony'
+        include:
+          # PHP 8.5 (latest)
+          - path: "8.5"
+            tags: |
+              silarhi/php-apache:latest
+              silarhi/php-apache:8.5
+          - path: "8.5-ci"
+            tags: silarhi/php-apache:8.5-ci
+          - path: "8.5-frankenphp-alpine"
+            tags: silarhi/php-apache:8.5-frankenphp-alpine
+          - path: "8.5-frankenphp-bookworm"
+            tags: silarhi/php-apache:8.5-frankenphp-bookworm
+          - path: "8.5-symfony"
+            tags: silarhi/php-apache:8.5-symfony
+
+          # PHP 8.4
+          - path: "8.4"
+            tags: silarhi/php-apache:8.4
+          - path: "8.4-ci"
+            tags: silarhi/php-apache:8.4-ci
+          - path: "8.4-frankenphp-alpine"
+            tags: silarhi/php-apache:8.4-frankenphp-alpine
+          - path: "8.4-frankenphp-bookworm"
+            tags: silarhi/php-apache:8.4-frankenphp-bookworm
+          - path: "8.4-symfony"
+            tags: silarhi/php-apache:8.4-symfony
+
+          # PHP 8.3
+          - path: "8.3"
+            tags: silarhi/php-apache:8.3
+          - path: "8.3-ci"
+            tags: silarhi/php-apache:8.3-ci
+          - path: "8.3-frankenphp-alpine"
+            tags: silarhi/php-apache:8.3-frankenphp-alpine
+          - path: "8.3-frankenphp-bookworm"
+            tags: silarhi/php-apache:8.3-frankenphp-bookworm
+          - path: "8.3-symfony"
+            tags: silarhi/php-apache:8.3-symfony
+
+          # PHP 8.2
+          - path: "8.2"
+            tags: silarhi/php-apache:8.2
+          - path: "8.2-ci"
+            tags: silarhi/php-apache:8.2-ci
+          - path: "8.2-frankenphp-alpine"
+            tags: silarhi/php-apache:8.2-frankenphp-alpine
+          - path: "8.2-frankenphp-bookworm"
+            tags: silarhi/php-apache:8.2-frankenphp-bookworm
+          - path: "8.2-symfony"
+            tags: silarhi/php-apache:8.2-symfony
+
+          # PHP 8.1
+          - path: "8.1"
+            tags: silarhi/php-apache:8.1
+          - path: "8.1-ci"
+            tags: silarhi/php-apache:8.1-ci
+          - path: "8.1-symfony"
+            tags: silarhi/php-apache:8.1-symfony
+
     steps:
-      - 
-        name: Prepare paths and tags
-        uses: winterjung/split@v2
-        id: split
-        with:
-          msg: ${{ matrix.path-and-tag }}
-          separator: ':'
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v5
-      -
-        name: Set up QEMU
+
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Login to DockerHub
+
+      - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
+
+      - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: ${{ steps.split.outputs._0 }}
+          context: ${{ matrix.path }}
           platforms: linux/amd64,linux/arm64
-          tags: ${{ format('silarhi/php-apache:{0}', steps.split.outputs._1) }}
+          tags: ${{ matrix.tags }}
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
- Restructured matrix to use separate 'path' and 'tags' fields for better readability
- Added comments to group PHP versions for easier navigation
- Consolidated PHP 8.5 base variant to push both 'latest' and '8.5' tags in a single job
- Removed unnecessary winterjung/split action dependency
- Improved step formatting with consistent spacing
- Reduced overall line length for better code review experience

This reduces the number of jobs by consolidating the 8.5 variant that was previously split into 3 separate jobs (8.5:latest, 8.5:8.5, 8.5-ci:8.5-ci) into a more efficient structure where the base 8.5 image is built once and tagged with both 'latest' and '8.5'.