### PR TITLE
Add link GitHub repo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 A Docker image for PHP apps based on Debian. Works with Apache and PHP from 5.6 to 8.4 and provide a Symfony variant.
 
+* GitHub: https://github.com/silarhi/docker-php
 * Demo: https://labs.silarhi.fr/php
 * Demo (404): https://labs.silarhi.fr/php/notfound
 * Docker image: https://hub.docker.com/r/silarhi/php-apache


### PR DESCRIPTION
The GitHub repo link is referenced on Docker Hub but was missing from the README itself. Added it to the list of links for better discoverability.