### PR TITLE
Restore removed ICU package installation

### DIFF
--- a/7.4-ci/Dockerfile
+++ b/7.4-ci/Dockerfile
@@ -13,7 +13,8 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 # Install dependencies
 RUN apk add --no-cache \
     bash \
-    git
+    git \
+    icu
 
 # PHP Extensions
 COPY --from=php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/

--- a/8.0-ci/Dockerfile
+++ b/8.0-ci/Dockerfile
@@ -13,7 +13,8 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 # Install dependencies
 RUN apk add --no-cache \
     bash \
-    git
+    git \
+    icu
 
 # PHP Extensions
 COPY --from=php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/

--- a/8.1-ci/Dockerfile
+++ b/8.1-ci/Dockerfile
@@ -13,7 +13,8 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 # Install dependencies
 RUN apk add --no-cache \
     bash \
-    git
+    git \
+    icu
 
 # PHP Extensions
 COPY --from=php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/

--- a/8.2-ci/Dockerfile
+++ b/8.2-ci/Dockerfile
@@ -13,7 +13,8 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 # Install dependencies
 RUN apk add --no-cache \
     bash \
-    git
+    git \
+    icu
 
 # PHP Extensions
 COPY --from=php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/

--- a/8.3-ci/Dockerfile
+++ b/8.3-ci/Dockerfile
@@ -13,7 +13,8 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 # Install dependencies
 RUN apk add --no-cache \
     bash \
-    git
+    git \
+    icu
 
 # PHP Extensions
 COPY --from=php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/

--- a/8.4-ci/Dockerfile
+++ b/8.4-ci/Dockerfile
@@ -13,7 +13,8 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 # Install dependencies
 RUN apk add --no-cache \
     bash \
-    git
+    git \
+    icu
 
 # PHP Extensions
 COPY --from=php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/

--- a/8.5-ci/Dockerfile
+++ b/8.5-ci/Dockerfile
@@ -13,7 +13,8 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 # Install dependencies
 RUN apk add --no-cache \
     bash \
-    git
+    git \
+    icu
 
 # PHP Extensions
 COPY --from=php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/


### PR DESCRIPTION
Re-added the icu runtime package to Alpine-based CI variant Dockerfiles (7.4-ci through 8.5-ci). This package was removed in commit c019976 when switching to docker-php-extension-installer, but is needed as a runtime dependency for the intl PHP extension.

Changes:
- Added icu to apk add --no-cache in all CI variants (7.4-ci, 8.0-ci, 8.1-ci, 8.2-ci, 8.3-ci, 8.4-ci, 8.5-ci)